### PR TITLE
Delete duplicate objects in ALV list.

### DIFF
--- a/core/ZSAPLINK/PROG/ZSAPLINK.slnk
+++ b/core/ZSAPLINK/PROG/ZSAPLINK.slnk
@@ -2138,6 +2138,8 @@ FORM nugget_add_from_transport .
     EXIT.
   ENDIF.
 
+  SORT it_requestobject.
+  DELETE ADJACENT DUPLICATES FROM it_requestobject.
   LOOP AT it_requestobject INTO wa_requestobject.
     MOVE-CORRESPONDING wa_requestobject TO packageline.
     APPEND packageline TO objects_package.


### PR DESCRIPTION
Duplicity occurs when adding objects from a request with copy transports.