### PR TITLE
Adding $TMP package now only adds my objects

### DIFF
--- a/core/ZSAPLINK/PROG/ZSAPLINK.slnk
+++ b/core/ZSAPLINK/PROG/ZSAPLINK.slnk
@@ -2045,11 +2045,20 @@ FORM nugget_add_package .
   IF sy-saprl NE &apos;701&apos;.
     &quot;// Mar: Added logic discard deleted objects from Package - 10/05/2009
 
-    SELECT object obj_name srcsystem       &quot; ##TOO_MANY_ITAB_FIELDS
-        FROM tadir
-        INTO CORRESPONDING FIELDS OF TABLE objects_package
-        WHERE devclass  EQ package
-        AND  pgmid      EQ &apos;R3TR&apos;.
+    IF package EQ &apos;$TMP&apos;.
+      SELECT object obj_name srcsystem       &quot; ##TOO_MANY_ITAB_FIELDS
+          FROM tadir
+          INTO CORRESPONDING FIELDS OF TABLE objects_package
+          WHERE devclass  EQ package
+          AND  author     EQ sy-uname
+          AND  pgmid      EQ &apos;R3TR&apos;.
+    ELSE.
+      SELECT object obj_name srcsystem       &quot; ##TOO_MANY_ITAB_FIELDS
+          FROM tadir
+          INTO CORRESPONDING FIELDS OF TABLE objects_package
+          WHERE devclass  EQ package
+          AND  pgmid      EQ &apos;R3TR&apos;.
+    ENDIF.
 
     &quot;// Mar: Added logic discard deleted objects from Package - 10/05/2009
   ELSE.


### PR DESCRIPTION
When you add a package to a nugget, SAPLink always added the whole package.
For $TMP only the objects of the currently logged-in user should be added.